### PR TITLE
Fix `earlierRef` and `laterRef` fields of `journeys()` response

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,8 +248,8 @@ const createClient = (profile, userAgent, opt = {}) => {
 		}
 
 		return {
-			earlierRef: res.previousPageCursor,
-			laterRef: res.nextPageCursor,
+			earlierRef: res.data.previousPageCursor,
+			laterRef: res.data.nextPageCursor,
 			journeys,
 			realtimeDataUpdatedAt: null, // TODO
 		};


### PR DESCRIPTION
The `earlierRef` and `laterRef` fields were undefined, since the value they were assigned to points to nowhere