### PR TITLE
Fix stopovers realtime data

### DIFF
--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -55,7 +55,7 @@ const parseJourneyLeg = (ctx, pt, date) => { // pt = raw leg
 		}
 
 		if (opt.stopovers && pt.intermediateStops && pt.intermediateStops.length) {
-			res.stopovers = pt.intermediateStops.map(s => profile.parseStopover(ctx, s, date));
+			res.stopovers = pt.intermediateStops.map(s => profile.parseStopover(ctx, s, date, pt.realTime));
 			// filter stations the train passes without stopping, as this doesn't comply with fptf (yet)
 			res.stopovers = res.stopovers.filter((x) => !x.passBy);
 		}

--- a/parse/stopover.js
+++ b/parse/stopover.js
@@ -1,4 +1,4 @@
-const parseStopover = (ctx, st, date) => { // st = raw stopover
+const parseStopover = (ctx, st, date, realTime) => { // st = raw stopover
 	const {profile, opt} = ctx;
 
 	const cancelled = profile.parseCancelled(st);
@@ -6,14 +6,14 @@ const parseStopover = (ctx, st, date) => { // st = raw stopover
 		ctx,
 		null,
 		st.scheduledArrival,
-		st.realTime ? st.arrival : null,
+		realTime ? st.arrival : null,
 		cancelled);
 	const arrPl = profile.parsePlatform(ctx, st.scheduledTrack, st.track, cancelled);
 	const dep = profile.parseWhen(
 		ctx,
 		null,
 		st.scheduledDeparture,
-		st.realTime ? st.departure : null,
+		realTime ? st.departure : null,
 		cancelled);
 	const depPl = arrPl;
 


### PR DESCRIPTION
The objects in the `intermediatePlaces` array of a motis leg (`Place` objects) do not have a `realTime` field, so we have to use the one from the leg